### PR TITLE
Implement :limit and :order-by-vars. Fixes #37.

### DIFF
--- a/src/datomish/db.cljc
+++ b/src/datomish/db.cljc
@@ -643,10 +643,12 @@
   "Execute the provided query on the provided DB.
    Returns a transduced channel of [result err] pairs.
    Closes the channel when fully consumed."
-  [db find args]
-  (let [parsed (query/parse find)
+  [db find options]
+  (let [{:keys [limit order-by args]} options
+        parsed (query/parse find)
         context (-> db
                     query-context
+                    (query/options-into-context limit order-by)
                     (query/find-into-context parsed))
         row-pair-transducer (projection/row-pair-transducer context)
         sql (query/context->sql-string context args)
@@ -665,6 +667,8 @@
 (defn <?q
   "Execute the provided query on the provided DB.
    Returns a transduced pair-chan with one [[results] err] item."
-  [db find args]
-  (a/reduce (partial reduce-error-pair conj) [[] nil]
-            (<?run db find args)))
+  ([db find]
+   (<?q db find {}))
+  ([db find options]
+   (a/reduce (partial reduce-error-pair conj) [[] nil]
+             (<?run db find options))))

--- a/src/datomish/query/context.cljc
+++ b/src/datomish/query/context.cljc
@@ -12,8 +12,10 @@
    elements        ; The :find list itself.
    has-aggregates?
    group-by-vars   ; A list of variables from :find and :with, used to generate GROUP BY.
+   order-by-vars   ; A list of projected variables and directions, e.g., [:date :asc], [:_max_timestamp :desc].
+   limit           ; The limit to apply to the final results of the query. Only makes sense with ORDER BY.
    cc              ; The main conjoining clause.
    ])
 
 (defn make-context [source]
-  (->Context source nil false nil nil))
+  (->Context source nil false nil nil nil nil))

--- a/test/datomish/tofinoish_test.cljc
+++ b/test/datomish/tofinoish_test.cljc
@@ -176,8 +176,7 @@
       [?id :session/startReason ?reason ?tx]
       [?tx :db/txInstant ?ts]
       (not-join [?id]
-        [?id :session/endReason _])]
-    {}))
+        [?id :session/endReason _])]))
 
 (defn <ended-sessions [db]
   (d/<q
@@ -185,8 +184,7 @@
     '[:find ?id ?endReason ?ts :in $
       :where
       [?id :session/endReason ?endReason ?tx]
-      [?tx :db/txInstant ?ts]]
-    {}))
+      [?tx :db/txInstant ?ts]]))
 
 (defn <star-page [conn {:keys [url uri title session]}]
   (let [page (d/id-literal :db.part/user -1)]
@@ -214,8 +212,7 @@
             [?tx :db/txInstant ?starredOn]
             [?page :page/url ?uri]
             [?page :page/title ?title]                   ; N.B., this means we will exclude pages with no title.
-            ]
-          {}))
+            ]))
 
       (map (fn [[page uri title starredOn]]
              {:page page :uri uri :title title :starredOn starredOn})))))
@@ -248,8 +245,7 @@
           [?save :save/page ?page]
           [?page :page/url ?url]
           [(get-else $ ?save :save/title "") ?title]
-          [(get-else $ ?save :save/excerpt "") ?excerpt]]
-        {}))
+          [(get-else $ ?save :save/excerpt "") ?excerpt]]))
 
 (defn <saved-pages-matching-string [db string]
   (d/<q db
@@ -259,8 +255,7 @@
                  '[?save :save/page ?page]
                  '[?page :page/url ?url]
                  '[(get-else $ ?save :save/title "") ?title]
-                 '[(get-else $ ?save :save/excerpt "") ?excerpt]]}
-        {}))
+                 '[(get-else $ ?save :save/excerpt "") ?excerpt]]}))
 
 
 ;; TODO: return ID?
@@ -305,13 +300,12 @@
                        {:find '[?uri ?title (max ?time)]
                         :in (if since '[$ ?since] '[$])
                         :where where}
-                       {:since since}))]
-      (->>
-        rows
-        (sort-by (comp unchecked-negate third))    ;; TODO: these should be dates!
-        (take limit)
+                       {:limit limit
+                        :order-by [[:_max_time :desc]]
+                        :args {:since since}}))]
         (map (fn [[uri title lastVisited]]
-               {:uri uri :title title :lastVisited lastVisited})))))))
+               {:uri uri :title title :lastVisited lastVisited})
+             rows)))))
 
 (defn <find-title [db url]
   ;; Until we support [:find ?title . :in…] we crunch this by hand.
@@ -324,7 +318,7 @@
                   :where
                   [?page :page/url ?url]
                   [(get-else $ ?page :page/title "") ?title]]
-                {:url url}))))))
+                {:args {:url url}}))))))
 
 ;; Ensure that we can grow the schema over time.
 (deftest-db test-schema-evolution conn
@@ -385,10 +379,12 @@
     (<? (<add-visit conn {:uri "http://notitle.example.org/"
                           :session session}))
     (is (= "" (<? (<find-title (d/db conn) "http://notitle.example.org/"))))
-    (is (= (select-keys (first (<? (<visited (d/db conn) {:limit 1})))
-                        [:uri :title])
-           {:uri "http://notitle.example.org/"
-            :title ""}))
+    (let [only-one (<? (<visited (d/db conn) {:limit 1}))]
+      (is (= 1 (count only-one)))
+      (is (= (select-keys (first only-one)
+                          [:uri :title])
+             {:uri "http://notitle.example.org/"
+              :title ""})))
 
     ;; If we end this one, then it's no longer active but is ended.
     (<? (<end-session conn {:session session}))


### PR DESCRIPTION
We'd like this to be part of the query syntax itself, but doing so requires extending DataScript's parser.

This has a simple positive test by way of the Tofinoish `<visited` check, but I'll write some more to validate projection checks and such.