### PR TITLE
Serialize and de-serialize non-keyword schema values correctly. Fixes #52.

### DIFF
--- a/src/datomish/db.cljc
+++ b/src/datomish/db.cljc
@@ -655,12 +655,21 @@
 
   (<apply-db-install-assertions [db fragment merge]
     (go-pair
-      (let [exec (partial s/execute! (:sqlite-connection db))]
+      (let [schema         (.-schema db)
+            ->SQLite       (partial ds/->SQLite schema)
+            exec (partial s/execute! (:sqlite-connection db))]
         ;; TODO: batch insert.
         (doseq [[ident attr-map] fragment]
           (doseq [[attr value] attr-map]
-            (<? (exec
-                  ["INSERT INTO schema VALUES (?, ?, ?)" (sqlite-schema/->SQLite ident) (sqlite-schema/->SQLite attr) (sqlite-schema/->SQLite value)])))))
+            ;; This is a little sloppy.  We need to store idents as entids, since they're (mostly)
+            ;; :db.type/ref attributes.  So we use that entid passes through idents it doesn't
+            ;; recognize, and assuming that we have no :db.type/keyword values that match idents.
+            ;; This is safe for now.
+            (let [[v tag] (->SQLite (entid db attr) (entid db value))]
+              (<? (exec
+                    ["INSERT INTO schema VALUES (?, ?, ?, ?)"
+                     (sqlite-schema/->SQLite ident) (sqlite-schema/->SQLite attr)
+                     v tag]))))))
 
       (let [symbolic-schema (merge-with merge (:symbolic-schema db) fragment)
             schema          (ds/schema (into {} (map (fn [[k v]] [(entid db k) v]) symbolic-schema)))]

--- a/src/datomish/db.cljc
+++ b/src/datomish/db.cljc
@@ -172,15 +172,63 @@
      :table-alias source/gensym-table-alias
      :make-constraints nil}))
 
+;; TODO: make this not do the tx_lookup.  We could achieve this by having additional special values
+;; of added0, or by separating the tx_lookup table into before and after tables.
+(defn- retractAttributes->queries [eas tx]
+  (let [where-part
+        "(e = ? AND a = ?)"
+
+        repeater (memoize (fn [n] (interpose " OR " (repeat n where-part))))]
+    (map
+      (fn [chunk]
+        (cons
+          (apply str
+                 "INSERT INTO tx_lookup (e0, a0, v0, tx0, added0, value_type_tag0, sv, svalue_type_tag)
+                SELECT e, a, v, ?, 0, value_type_tag, v, value_type_tag
+                FROM datoms
+                WHERE "
+                 (repeater (count chunk)))
+          (cons
+            tx
+            (mapcat (fn [[_ e a]]
+                      [e a])
+                    chunk))))
+      (partition-all (quot (dec max-sql-vars) 2) eas))))
+
+;; TODO: make this not do the tx_lookup.  We could achieve this by having additional special values
+;; of added0, or by separating the tx_lookup table into before and after tables.
+(defn- retractEntities->queries [es tx]
+  (let [where-part
+        "e = ? OR (v = ? AND value_type_tag = ?)"
+
+        repeater (memoize (fn [n] (interpose " OR " (repeat n where-part))))
+
+        ref-tag (sqlite-schema/->tag :db.type/ref)]
+    (map
+      (fn [chunk]
+        (cons
+          (apply str
+                 "INSERT INTO tx_lookup (e0, a0, v0, tx0, added0, value_type_tag0, sv, svalue_type_tag)
+                SELECT e, a, v, ?, 0, value_type_tag, v, value_type_tag
+                FROM datoms
+                WHERE "
+                 (repeater (count chunk)))
+          (cons
+            tx
+            (mapcat (fn [[_ e]]
+                      [e e ref-tag])
+                    chunk))))
+      (partition-all (quot (dec max-sql-vars) 3) es))))
+
 (defn- retractions->queries [retractions tx fulltext? ->SQLite]
   (let
-    [f-q
-     "WITH vv AS (SELECT rowid FROM fulltext_values WHERE text = ?)
+      [f-q
+       "WITH vv AS (SELECT rowid FROM fulltext_values WHERE text = ?)
      INSERT INTO tx_lookup (e0, a0, v0, tx0, added0, value_type_tag0, sv, svalue_type_tag)
      VALUES (?, ?, (SELECT rowid FROM vv), ?, 0, ?, (SELECT rowid FROM vv), ?)"
 
-     non-f-q
-     "INSERT INTO tx_lookup (e0, a0, v0, tx0, added0, value_type_tag0, sv, svalue_type_tag)
+       non-f-q
+       "INSERT INTO tx_lookup (e0, a0, v0, tx0, added0, value_type_tag0, sv, svalue_type_tag)
      VALUES (?, ?, ?, ?, 0, ?, ?, ?)"]
     (map
       (fn [[_ e a v]]
@@ -394,7 +442,7 @@
           SELECT e, a, v, ?, 0, value_type_tag
           FROM tx_lookup
           WHERE added0 IS 2 AND ((sv IS NOT NULL) OR (sv IS NULL AND v0 IS NOT v)) AND v IS NOT NULL" tx] ;; TODO: get rid of magic value 2.
-]
+        ]
     (go-pair
       (doseq [q [build-indices insert-into-tx-lookup
                  t-datoms-not-already-present
@@ -431,15 +479,26 @@
         queries (atom [])
         operations (group-by first entities)]
 
-    (when-not (clojure.set/subset? (keys operations) #{:db/retract :db/add})
-      (raise (str "Unknown operations " (keys operations))
-             {:error :transact/syntax, :operations (dissoc operations :db/retract :db/add)}))
+    ;; Belt and braces.  At this point, we should have already errored out if op is not known.
+    (let [known #{:db/retract :db/add :db.fn/retractAttribute :db.fn/retractEntity}]
+      (when-not (clojure.set/subset? (keys operations) known)
+        (let [unknown (apply dissoc operations known)]
+          (raise (str "Unknown operations " (apply sorted-set (keys unknown)))
+                 {:error :transact/syntax, :operations (apply sorted-set (keys unknown))}))))
 
     ;; We can turn all non-FTS operations into simple SQL queries that we run serially.
     ;; FTS queries require us to get a rowid from the FTS table and use that for
     ;; insertion, so we need another pass.
     ;; We can't just freely use `go-pair` here, because this function is so complicated
     ;; that ClojureScript blows the stack trying to compile it.
+
+    (when-let [eas (:db.fn/retractAttribute operations)]
+      (swap!
+        queries concat (retractAttributes->queries eas tx)))
+
+    (when-let [es (:db.fn/retractEntity operations)]
+      (swap!
+        queries concat (retractEntities->queries es tx)))
 
     (when-let [retractions (:db/retract operations)]
       (swap!

--- a/src/datomish/db_factory.cljc
+++ b/src/datomish/db_factory.cljc
@@ -97,7 +97,6 @@
                                                new))]
           (let [exec (partial s/execute! (:sqlite-connection db))
                 part->vector (fn [[part {:keys [start idx]}]]
-                               (println "part->vector" part start idx)
                                [(sqlite-schema/->SQLite part) start idx])]
             ;; TODO: allow inserting new parts.
             ;; TODO: think more carefully about allocating new parts and bitmasking part ranges.

--- a/src/datomish/db_factory.cljc
+++ b/src/datomish/db_factory.cljc
@@ -45,26 +45,34 @@
                      (s/all-rows sqlite-connection)))]
       (into {} (map (fn [row] [(sqlite-schema/<-SQLite :db.type/keyword (:part row)) (select-keys row [:start :idx])])) rows))))
 
-(defn <symbolic-schema [sqlite-connection]
+(defn <symbolic-schema [sqlite-connection idents]
   "Read the schema map materialized view from the given SQLite store.
   Returns a map (keyword ident) -> (map (keyword attribute -> keyword value)), like
   {:db/ident {:db/cardinality :db.cardinality/one}}."
 
   (go-pair
-    (->>
+    (let [ident-map (into {} (clojure.set/map-invert idents))
+          ref-tag   (sqlite-schema/->tag :db.type/ref)]
       (->>
-        {:select [:ident :attr :value] :from [:schema]}
-        (s/format)
-        (s/all-rows sqlite-connection))
-      (<?)
+        (->>
+          {:select [:ident :attr :value :value_type_tag] :from [:schema]}
+          (s/format)
+          (s/all-rows sqlite-connection))
+        (<?)
 
-      (group-by (comp (partial sqlite-schema/<-SQLite :db.type/keyword) :ident))
-      (map (fn [[ident rows]]
-             [ident
-              (into {} (map (fn [row]
-                              [(sqlite-schema/<-SQLite :db.type/keyword (:attr row))
-                               (sqlite-schema/<-SQLite :db.type/keyword (:value row))]) rows))])) ;; TODO: this is wrong, it doesn't handle true.
-      (into {}))))
+        (group-by (comp (partial sqlite-schema/<-SQLite :db.type/keyword) :ident))
+        (map (fn [[ident rows]]
+               [ident
+                (into {} (map (fn [row]
+                                (let [tag (:value_type_tag row)
+                                      ;; We want a symbolic schema, but most of our values are
+                                      ;; :db.type/ref attributes.  Map those entids back to idents.
+                                      ;; This is ad-hoc since we haven't built a function DB
+                                      ;; instance yet.
+                                      v   (if (= tag ref-tag) (get ident-map (:value row)) (:value row))]
+                                  [(sqlite-schema/<-SQLite :db.type/keyword (:attr row))
+                                   (sqlite-schema/<-tagged-SQLite tag v)])) rows))]))
+        (into {})))))
 
 (defn <initialize-connection [sqlite-connection]
   (go-pair
@@ -121,7 +129,7 @@
       ;; We just bootstrapped, or we are returning to an already bootstrapped DB.
       (let [idents          (<? (<idents sqlite-connection))
             parts           (<? (<parts sqlite-connection))
-            symbolic-schema (<? (<symbolic-schema sqlite-connection))]
+            symbolic-schema (<? (<symbolic-schema sqlite-connection idents))]
         (when-not bootstrapped?
           (when (not (= idents bootstrap/idents))
             (raise "After bootstrapping database, expected new materialized idents and old bootstrapped idents to be identical"

--- a/src/datomish/sqlite_schema.cljc
+++ b/src/datomish/sqlite_schema.cljc
@@ -109,9 +109,9 @@
 
    ;; Materialized views of the schema.
    "CREATE TABLE idents (ident TEXT NOT NULL PRIMARY KEY, entid INTEGER UNIQUE NOT NULL)"
-   ;; TODO: allow arbitrary schema values (true/false) and tag the resulting values.
-   "CREATE TABLE schema (ident TEXT NOT NULL, attr TEXT NOT NULL, value TEXT NOT NULL, FOREIGN KEY (ident) REFERENCES idents (ident))"
-   "CREATE INDEX idx_schema_unique ON schema (ident, attr, value)"
+   "CREATE TABLE schema (ident TEXT NOT NULL, attr TEXT NOT NULL, value BLOB NOT NULL, value_type_tag SMALLINT NOT NULL,
+   FOREIGN KEY (ident) REFERENCES idents (ident))"
+   "CREATE INDEX idx_schema_unique ON schema (ident, attr, value, value_type_tag)"
    "CREATE TABLE parts (part TEXT NOT NULL PRIMARY KEY, start INTEGER NOT NULL, idx INTEGER NOT NULL)"
    ])
 

--- a/src/datomish/test_macros.cljc
+++ b/src/datomish/test_macros.cljc
@@ -5,8 +5,7 @@
 (ns datomish.test-macros
   #?(:cljs
      (:require-macros
-        [datomish.test-macros]
-        [datomish.node-tempfile-macros]))
+      [datomish.test-macros]))
   (:require
    [datomish.pair-chan]))
 
@@ -44,16 +43,8 @@
 (defmacro deftest-db
   [n conn-var & body]
   `(deftest-async ~n
-    (if-cljs
-      (datomish.node-tempfile-macros/with-tempfile [t# (datomish.node-tempfile/tempfile)]
-         (let [~conn-var (datomish.pair-chan/<? (datomish.api/<connect t#))]
-           (try
-             ~@body
-             (finally
-               (datomish.pair-chan/<? (datomish.api/<close ~conn-var))))))
-      (tempfile.core/with-tempfile [t# (tempfile.core/tempfile)]
-       (let [~conn-var (datomish.pair-chan/<? (datomish.api/<connect t#))]
-         (try
-           ~@body
-           (finally
-             (datomish.pair-chan/<? (datomish.api/<close ~conn-var)))))))))
+     (let [~conn-var (datomish.pair-chan/<? (datomish.api/<connect ""))]
+       (try
+         ~@body
+         (finally
+           (datomish.pair-chan/<? (datomish.api/<close ~conn-var)))))))

--- a/src/datomish/transact/bootstrap.cljc
+++ b/src/datomish/transact/bootstrap.cljc
@@ -19,7 +19,7 @@
    ;;                       :db/cardinality :db.cardinality/many}
    :db/txInstant         {:db/valueType   :db.type/long
                           :db/cardinality :db.cardinality/one
-                          } ;; :db/index       true} TODO: Handle this using SQLite protocol.
+                          :db/index       true}
    :db/valueType         {:db/valueType   :db.type/ref
                           :db/cardinality :db.cardinality/one}
    :db/cardinality       {:db/valueType   :db.type/ref

--- a/test/datomish/db_test.cljc
+++ b/test/datomish/db_test.cljc
@@ -19,12 +19,12 @@
    #?@(:clj [[datomish.jdbc-sqlite]
              [datomish.pair-chan :refer [go-pair <?]]
              [tempfile.core :refer [tempfile with-tempfile]]
-             [datomish.test-macros :refer [deftest-async]]
+             [datomish.test-macros :refer [deftest-async deftest-db]]
              [clojure.test :as t :refer [is are deftest testing]]
              [clojure.core.async :refer [go <! >!]]])
    #?@(:cljs [[datomish.promise-sqlite]
               [datomish.pair-chan]
-              [datomish.test-macros :refer-macros [deftest-async]]
+              [datomish.test-macros :refer-macros [deftest-async deftest-db]]
               [datomish.node-tempfile :refer [tempfile]]
               [cljs.test :as t :refer-macros [is are deftest testing async]]
               [cljs.core.async :as a :refer [<! >!]]]))
@@ -81,541 +81,445 @@
     :db.install/_attribute :db.part/db}
    ])
 
-(deftest-async test-add-one
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [{tx0 :tx} (<? (d/<transact! conn test-schema))]
-          (let [{:keys [tx txInstant]} (<? (d/<transact! conn [[:db/add 0 :name "valuex"]]))]
-            (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[0 :name "valuex"]}))
-            (is (= (<? (<transactions-after (d/db conn) tx0))
-                   [[0 :name "valuex" tx 1] ;; TODO: true, not 1.
-                    [tx :db/txInstant txInstant tx 1]]))))
-        (finally
-          (<? (d/<close conn)))))))
+(deftest-db test-add-one conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))]
+    (let [{:keys [tx txInstant]} (<? (d/<transact! conn [[:db/add 0 :name "valuex"]]))]
+      (is (= (<? (<datoms-after (d/db conn) tx0))
+             #{[0 :name "valuex"]}))
+      (is (= (<? (<transactions-after (d/db conn) tx0))
+             [[0 :name "valuex" tx 1] ;; TODO: true, not 1.
+              [tx :db/txInstant txInstant tx 1]])))))
 
-(deftest-async test-add-two
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
-              {tx1 :tx txInstant1 :txInstant} (<? (d/<transact! conn [[:db/add 1 :name "Ivan"]]))
-              {tx2 :tx txInstant2 :txInstant} (<? (d/<transact! conn [[:db/add 1 :name "Petr"]]))
-              {tx3 :tx txInstant3 :txInstant} (<? (d/<transact! conn [[:db/add 1 :aka "Tupen"]]))
-              {tx4 :tx txInstant4 :txInstant} (<? (d/<transact! conn [[:db/add 1 :aka "Devil"]]))]
-          (is (= (<? (<datoms-after (d/db conn) tx0))
-                 #{[1 :name "Petr"]
-                   [1 :aka  "Tupen"]
-                   [1 :aka  "Devil"]}))
+(deftest-db test-add-two conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
+        {tx1 :tx txInstant1 :txInstant} (<? (d/<transact! conn [[:db/add 1 :name "Ivan"]]))
+        {tx2 :tx txInstant2 :txInstant} (<? (d/<transact! conn [[:db/add 1 :name "Petr"]]))
+        {tx3 :tx txInstant3 :txInstant} (<? (d/<transact! conn [[:db/add 1 :aka "Tupen"]]))
+        {tx4 :tx txInstant4 :txInstant} (<? (d/<transact! conn [[:db/add 1 :aka "Devil"]]))]
+    (is (= (<? (<datoms-after (d/db conn) tx0))
+           #{[1 :name "Petr"]
+             [1 :aka  "Tupen"]
+             [1 :aka  "Devil"]}))
 
-          (is (= (<? (<transactions-after (d/db conn) tx0))
-                 [[1 :name "Ivan" tx1 1] ;; TODO: true, not 1.
-                  [tx1 :db/txInstant txInstant1 tx1 1]
-                  [1 :name "Ivan" tx2 0]
-                  [1 :name "Petr" tx2 1]
-                  [tx2 :db/txInstant txInstant2 tx2 1]
-                  [1 :aka "Tupen" tx3 1]
-                  [tx3 :db/txInstant txInstant3 tx3 1]
-                  [1 :aka "Devil" tx4 1]
-                  [tx4 :db/txInstant txInstant4 tx4 1]])))
+    (is (= (<? (<transactions-after (d/db conn) tx0))
+           [[1 :name "Ivan" tx1 1] ;; TODO: true, not 1.
+            [tx1 :db/txInstant txInstant1 tx1 1]
+            [1 :name "Ivan" tx2 0]
+            [1 :name "Petr" tx2 1]
+            [tx2 :db/txInstant txInstant2 tx2 1]
+            [1 :aka "Tupen" tx3 1]
+            [tx3 :db/txInstant txInstant3 tx3 1]
+            [1 :aka "Devil" tx4 1]
+            [tx4 :db/txInstant txInstant4 tx4 1]]))))
 
-        (finally
-          (<? (d/<close conn)))))))
+(deftest-db test-retract conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
+        {tx1 :tx txInstant1 :txInstant} (<? (d/<transact! conn [[:db/add     0 :x 123]]))
+        {tx2 :tx txInstant2 :txInstant} (<? (d/<transact! conn [[:db/retract 0 :x 123]]))]
+    (is (= (<? (<datoms-after (d/db conn) tx0))
+           #{}))
+    (is (= (<? (<transactions-after (d/db conn) tx0))
+           [[0 :x 123 tx1 1]
+            [tx1 :db/txInstant txInstant1 tx1 1]
+            [0 :x 123 tx2 0]
+            [tx2 :db/txInstant txInstant2 tx2 1]]))))
 
-(deftest-async test-retract
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
-              {tx1 :tx txInstant1 :txInstant} (<? (d/<transact! conn [[:db/add     0 :x 123]]))
-              {tx2 :tx txInstant2 :txInstant} (<? (d/<transact! conn [[:db/retract 0 :x 123]]))]
-          (is (= (<? (<datoms-after (d/db conn) tx0))
-                 #{}))
-          (is (= (<? (<transactions-after (d/db conn) tx0))
-                 [[0 :x 123 tx1 1]
-                  [tx1 :db/txInstant txInstant1 tx1 1]
-                  [0 :x 123 tx2 0]
-                  [tx2 :db/txInstant txInstant2 tx2 1]])))
-        (finally
-          (<? (d/<close conn)))))))
+(deftest-db test-id-literal-1 conn
+  (let [tx0 (:tx (<? (d/<transact! conn test-schema)))
+        report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :x 0]
+                                       [:db/add (d/id-literal :db.part/user -1) :y 1]
+                                       [:db/add (d/id-literal :db.part/user -2) :y 2]
+                                       [:db/add (d/id-literal :db.part/user -2) :y 3]]))]
+    (is (= (keys (:tempids report)) ;; TODO: include values.
+           [(d/id-literal :db.part/user -1)
+            (d/id-literal :db.part/user -2)]))
 
-(deftest-async test-id-literal-1
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [tx0 (:tx (<? (d/<transact! conn test-schema)))
-              report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :x 0]
-                                             [:db/add (d/id-literal :db.part/user -1) :y 1]
-                                             [:db/add (d/id-literal :db.part/user -2) :y 2]
-                                             [:db/add (d/id-literal :db.part/user -2) :y 3]]))]
-          (is (= (keys (:tempids report)) ;; TODO: include values.
-                 [(d/id-literal :db.part/user -1)
-                  (d/id-literal :db.part/user -2)]))
+    (let [eid1 (get-in report [:tempids (d/id-literal :db.part/user -1)])
+          eid2 (get-in report [:tempids (d/id-literal :db.part/user -2)])]
+      (is (= (<? (<datoms-after (d/db conn) tx0))
+             #{[eid1 :x 0]
+               [eid1 :y 1]
+               [eid2 :y 2]
+               [eid2 :y 3]})))))
 
-          (let [eid1 (get-in report [:tempids (d/id-literal :db.part/user -1)])
-                eid2 (get-in report [:tempids (d/id-literal :db.part/user -2)])]
-            (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[eid1 :x 0]
-                     [eid1 :y 1]
-                     [eid2 :y 2]
-                     [eid2 :y 3]}))))
+(deftest-db test-unique conn
+  (let [tx0 (:tx (<? (d/<transact! conn test-schema)))]
+    (testing "Multiple :db/unique values in tx-data violate unique constraint, no tempid"
+      (is (thrown-with-msg?
+            ExceptionInfo #"unique constraint"
+            (<? (d/<transact! conn [[:db/add 1 :x 0]
+                                    [:db/add 2 :x 0]])))))
 
-        (finally
-          (<? (d/<close conn)))))))
+    (testing "Multiple :db/unique values in tx-data violate unique constraint, tempid"
+      (is (thrown-with-msg?
+            ExceptionInfo #"unique constraint"
+            (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :spouse "Dana"]
+                                    [:db/add (d/id-literal :db.part/user -2) :spouse "Dana"]])))))))
 
-(deftest-async test-unique
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [tx0 (:tx (<? (d/<transact! conn test-schema)))]
-          (testing "Multiple :db/unique values in tx-data violate unique constraint, no tempid"
-            (is (thrown-with-msg?
-                  ExceptionInfo #"unique constraint"
-                  (<? (d/<transact! conn [[:db/add 1 :x 0]
-                                          [:db/add 2 :x 0]])))))
+(deftest-db test-valueType-keyword conn
+  (let [tx0 (:tx (<? (d/<transact! conn [{:db/id        (d/id-literal :db.part/user -1)
+                                          :db/ident     :test/kw
+                                          :db/unique    :db.unique/identity
+                                          :db/valueType :db.type/keyword}
+                                         {:db/id :db.part/db :db.install/attribute (d/id-literal :db.part/user -1)}])))]
 
-          (testing "Multiple :db/unique values in tx-data violate unique constraint, tempid"
-            (is (thrown-with-msg?
-                  ExceptionInfo #"unique constraint"
-                  (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :spouse "Dana"]
-                                          [:db/add (d/id-literal :db.part/user -2) :spouse "Dana"]]))))))
+    (let [report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :test/kw :test/kw1]]))
+          eid    (get-in report [:tempids (d/id-literal :db.part/user -1)])]
+      (is (= (<? (<datoms-after (d/db conn) tx0))
+             #{[eid :test/kw ":test/kw1"]})) ;; Value is raw.
 
-        (finally
-          (<? (d/<close conn)))))))
+      (testing "Adding the same value compares existing values correctly."
+        (<? (d/<transact! conn [[:db/add eid :test/kw :test/kw1]]))
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[eid :test/kw ":test/kw1"]}))) ;; Value is raw.
 
-(deftest-async test-valueType-keyword
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [tx0 (:tx (<? (d/<transact! conn [{:db/id        (d/id-literal :db.part/user -1)
-                                                :db/ident     :test/kw
-                                                :db/unique    :db.unique/identity
-                                                :db/valueType :db.type/keyword}
-                                               {:db/id :db.part/db :db.install/attribute (d/id-literal :db.part/user -1)}])))]
+      (testing "Upserting retracts existing value correctly."
+        (<? (d/<transact! conn [[:db/add eid :test/kw :test/kw2]]))
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[eid :test/kw ":test/kw2"]}))) ;; Value is raw.
 
-          (let [report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :test/kw :test/kw1]]))
-                eid    (get-in report [:tempids (d/id-literal :db.part/user -1)])]
-            (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[eid :test/kw ":test/kw1"]})) ;; Value is raw.
+      (testing "Retracting compares values correctly."
+        (<? (d/<transact! conn [[:db/retract eid :test/kw :test/kw2]]))
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{}))))))
 
-            (testing "Adding the same value compares existing values correctly."
-              (<? (d/<transact! conn [[:db/add eid :test/kw :test/kw1]]))
-              (is (= (<? (<datoms-after (d/db conn) tx0))
-                     #{[eid :test/kw ":test/kw1"]}))) ;; Value is raw.
+(deftest-db test-vector-upsert conn
+  ;; Not having DB-as-value really hurts us here.  This test only works because all upserts
+  ;; succeed on top of each other, so we never need to reset the underlying store.
+  (<? (d/<transact! conn test-schema))
+  (let [tx0 (:tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1"}
+                                         {:db/id 102 :name "Petr" :email "@2"}])))]
 
-            (testing "Upserting retracts existing value correctly."
-              (<? (d/<transact! conn [[:db/add eid :test/kw :test/kw2]]))
-              (is (= (<? (<datoms-after (d/db conn) tx0))
-                     #{[eid :test/kw ":test/kw2"]}))) ;; Value is raw.
+    (testing "upsert with tempid"
+      (let [report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :name "Ivan"]
+                                           [:db/add (d/id-literal :db.part/user -1) :age 12]]))]
+        (is (= (<? (<shallow-entity (d/db conn) 101))
+               {:name "Ivan" :age 12 :email "@1"}))
+        (is (= (tempids report)
+               {-1 101}))))
 
-            (testing "Retracting compares values correctly."
-              (<? (d/<transact! conn [[:db/retract eid :test/kw :test/kw2]]))
-              (is (= (<? (<datoms-after (d/db conn) tx0))
-                     #{})))))
+    (testing "upsert with tempid, order does not matter"
+      (let [report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :age 13]
+                                           [:db/add (d/id-literal :db.part/user -1) :name "Petr"]]))]
+        (is (= (<? (<shallow-entity (d/db conn) 102))
+               {:name "Petr" :age 13 :email "@2"}))
+        (is (= (tempids report)
+               {-1 102}))))
 
-        (finally
-          (<? (d/<close conn)))))))
+    (testing "Conflicting upserts fail"
+      (is (thrown-with-msg? Throwable #"Conflicting upsert"
+                            (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :name "Ivan"]
+                                                    [:db/add (d/id-literal :db.part/user -1) :age 35]
+                                                    [:db/add (d/id-literal :db.part/user -1) :name "Petr"]
+                                                    [:db/add (d/id-literal :db.part/user -1) :age 36]])))))))
 
-(deftest-async test-vector-upsert
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        ;; Not having DB-as-value really hurts us here.  This test only works because all upserts
-        ;; succeed on top of each other, so we never need to reset the underlying store.
-        (<? (d/<transact! conn test-schema))
-        (let [tx0 (:tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1"}
-                                               {:db/id 102 :name "Petr" :email "@2"}])))]
+(deftest-db test-map-upsert conn
+  ;; Not having DB-as-value really hurts us here.  This test only works because all upserts
+  ;; succeed on top of each other, so we never need to reset the underlying store.
+  (<? (d/<transact! conn test-schema))
+  (let [tx0 (:tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1"}
+                                         {:db/id 102 :name "Petr" :email "@2"}])))]
 
-          (testing "upsert with tempid"
-            (let [report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :name "Ivan"]
-                                                 [:db/add (d/id-literal :db.part/user -1) :age 12]]))]
-              (is (= (<? (<shallow-entity (d/db conn) 101))
-                     {:name "Ivan" :age 12 :email "@1"}))
-              (is (= (tempids report)
-                     {-1 101}))))
+    (testing "upsert with tempid"
+      (let [tx (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 35}]))]
+        (is (= (<? (<shallow-entity (d/db conn) 101))
+               {:name "Ivan" :email "@1" :age 35}))
+        (is (= (tempids tx)
+               {-1 101}))))
 
-          (testing "upsert with tempid, order does not matter"
-            (let [report (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :age 13]
-                                                 [:db/add (d/id-literal :db.part/user -1) :name "Petr"]]))]
-              (is (= (<? (<shallow-entity (d/db conn) 102))
-                     {:name "Petr" :age 13 :email "@2"}))
-              (is (= (tempids report)
-                     {-1 102}))))
+    (testing "upsert by 2 attrs with tempid"
+      (let [tx (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :email "@1" :age 35}]))]
+        (is (= (<? (<shallow-entity (d/db conn) 101))
+               {:name "Ivan" :email "@1" :age 35}))
+        (is (= (tempids tx)
+               {-1 101}))))
 
-          (testing "Conflicting upserts fail"
-            (is (thrown-with-msg? Throwable #"Conflicting upsert"
-                                  (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :name "Ivan"]
-                                                          [:db/add (d/id-literal :db.part/user -1) :age 35]
-                                                          [:db/add (d/id-literal :db.part/user -1) :name "Petr"]
-                                                          [:db/add (d/id-literal :db.part/user -1) :age 36]]))))))
-        (finally
-          (<? (d/<close conn)))))))
+    (testing "upsert with existing id"
+      (let [tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :age 36}]))]
+        (is (= (<? (<shallow-entity (d/db conn) 101))
+               {:name "Ivan" :email "@1" :age 36}))
+        (is (= (tempids tx)
+               {}))))
 
-(deftest-async test-map-upsert
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        ;; Not having DB-as-value really hurts us here.  This test only works because all upserts
-        ;; succeed on top of each other, so we never need to reset the underlying store.
-        (<? (d/<transact! conn test-schema))
-        (let [tx0 (:tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1"}
-                                               {:db/id 102 :name "Petr" :email "@2"}])))]
+    (testing "upsert by 2 attrs with existing id"
+      (let [tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1" :age 37}]))]
+        (is (= (<? (<shallow-entity (d/db conn) 101))
+               {:name "Ivan" :email "@1" :age 37}))
+        (is (= (tempids tx)
+               {}))))
 
-          (testing "upsert with tempid"
-            (let [tx (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 35}]))]
-              (is (= (<? (<shallow-entity (d/db conn) 101))
-                     {:name "Ivan" :email "@1" :age 35}))
-              (is (= (tempids tx)
-                     {-1 101}))))
+    (testing "upsert to two entities, resolve to same tempid, fails due to overlapping writes"
+      (is (thrown-with-msg? Throwable #"cardinality constraint"
+                            (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 35}
+                                                    {:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 36}])))))
 
-          (testing "upsert by 2 attrs with tempid"
-            (let [tx (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :email "@1" :age 35}]))]
-              (is (= (<? (<shallow-entity (d/db conn) 101))
-                     {:name "Ivan" :email "@1" :age 35}))
-              (is (= (tempids tx)
-                     {-1 101}))))
+    (testing "upsert to two entities, two tempids, fails due to overlapping writes"
+      (is (thrown-with-msg? Throwable #"cardinality constraint"
+                            (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 35}
+                                                    {:db/id (d/id-literal :db.part/user -2) :name "Ivan" :age 36}])))))))
 
-          (testing "upsert with existing id"
-            (let [tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :age 36}]))]
-              (is (= (<? (<shallow-entity (d/db conn) 101))
-                     {:name "Ivan" :email "@1" :age 36}))
-              (is (= (tempids tx)
-                     {}))))
+(deftest-db test-map-upsert-conflicts conn
+  ;; Not having DB-as-value really hurts us here.  This test only works because all upserts
+  ;; fail until the final one, so we never need to reset the underlying store.
+  (<? (d/<transact! conn test-schema))
+  (let [tx0 (:tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1"}
+                                         {:db/id 102 :name "Petr" :email "@2"}])))]
 
-          (testing "upsert by 2 attrs with existing id"
-            (let [tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1" :age 37}]))]
-              (is (= (<? (<shallow-entity (d/db conn) 101))
-                     {:name "Ivan" :email "@1" :age 37}))
-              (is (= (tempids tx)
-                     {}))))
+    ;; TODO: improve error message to refer to upsert inputs.
+    (testing "upsert conficts with existing id"
+      (is (thrown-with-msg? Throwable #"unique constraint"
+                            (<? (d/<transact! conn [{:db/id 102 :name "Ivan" :age 36}])))))
 
-          (testing "upsert to two entities, resolve to same tempid, fails due to overlapping writes"
-            (is (thrown-with-msg? Throwable #"cardinality constraint"
-                                  (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 35}
-                                                          {:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 36}])))))
+    ;; TODO: improve error message to refer to upsert inputs.
+    (testing "upsert conficts with non-existing id"
+      (is (thrown-with-msg? Throwable #"unique constraint"
+                            (<? (d/<transact! conn [{:db/id 103 :name "Ivan" :age 36}])))))
 
-          (testing "upsert to two entities, two tempids, fails due to overlapping writes"
-            (is (thrown-with-msg? Throwable #"cardinality constraint"
-                                  (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :age 35}
-                                                          {:db/id (d/id-literal :db.part/user -2) :name "Ivan" :age 36}]))))))
+    ;; TODO: improve error message to refer to upsert inputs.
+    (testing "upsert by 2 conflicting fields"
+      (is (thrown-with-msg? Throwable #"Conflicting upsert"
+                            (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :email "@2" :age 35}])))))
 
-        (finally
-          (<? (d/<close conn)))))))
+    (testing "upsert by non-existing value resolves as update"
+      (let [report (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :email "@3" :age 35}]))]
+        (is (= (<? (<shallow-entity (d/db conn) 101))
+               {:name "Ivan" :email "@3" :age 35}))
+        (is (= (tempids report)
+               {-1 101}))))))
 
-(deftest-async test-map-upsert-conflicts
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        ;; Not having DB-as-value really hurts us here.  This test only works because all upserts
-        ;; fail until the final one, so we never need to reset the underlying store.
-        (<? (d/<transact! conn test-schema))
-        (let [tx0 (:tx (<? (d/<transact! conn [{:db/id 101 :name "Ivan" :email "@1"}
-                                               {:db/id 102 :name "Petr" :email "@2"}])))]
+(deftest-db test-add-ident conn
+  (is (= :test/ident (d/entid (d/db conn) :test/ident)))
 
-          ;; TODO: improve error message to refer to upsert inputs.
-          (testing "upsert conficts with existing id"
-            (is (thrown-with-msg? Throwable #"unique constraint"
-                                  (<? (d/<transact! conn [{:db/id 102 :name "Ivan" :age 36}])))))
+  (let [report   (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/db -1) :db/ident :test/ident]]))
+        eid      (get-in report [:tempids (d/id-literal :db.part/db -1)])]
+    (is (= eid (d/entid (d/db conn) :test/ident)))
+    (is (= :test/ident (d/ident (d/db conn) eid))))
 
-          ;; TODO: improve error message to refer to upsert inputs.
-          (testing "upsert conficts with non-existing id"
-            (is (thrown-with-msg? Throwable #"unique constraint"
-                                  (<? (d/<transact! conn [{:db/id 103 :name "Ivan" :age 36}])))))
+  ;; TODO: This should fail, but doesn't, due to stringification of :test/ident.
+  ;; (is (thrown-with-msg?
+  ;;       ExceptionInfo #"Retracting a :db/ident is not yet supported, got "
+  ;;       (<? (d/<transact! conn [[:db/retract 44 :db/ident :test/ident]]))))
 
-          ;; TODO: improve error message to refer to upsert inputs.
-          (testing "upsert by 2 conflicting fields"
-            (is (thrown-with-msg? Throwable #"Conflicting upsert"
-                                  (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :email "@2" :age 35}])))))
+  ;; ;; Renaming looks like retraction and then assertion.
+  ;; (is (thrown-with-msg?
+  ;;       ExceptionInfo #"Retracting a :db/ident is not yet supported, got"
+  ;;       (<? (d/<transact! conn [[:db/add 44 :db/ident :other-name]]))))
 
-          (testing "upsert by non-existing value resolves as update"
-            (let [report (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :name "Ivan" :email "@3" :age 35}]))]
-              (is (= (<? (<shallow-entity (d/db conn) 101))
-                     {:name "Ivan" :email "@3" :age 35}))
-              (is (= (tempids report)
-                     {-1 101})))))
+  ;; (is (thrown-with-msg?
+  ;;       ExceptionInfo #"Re-asserting a :db/ident is not yet supported, got"
+  ;;       (<? (d/<transact! conn [[:db/add 55 :db/ident :test/ident]]))))
+  )
 
-        (finally
-          (<? (d/<close conn)))))))
-
-(deftest-async test-add-ident
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (is (= :test/ident (d/entid (d/db conn) :test/ident)))
-
-        (let [report   (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/db -1) :db/ident :test/ident]]))
-              eid      (get-in report [:tempids (d/id-literal :db.part/db -1)])]
-          (is (= eid (d/entid (d/db conn) :test/ident)))
-          (is (= :test/ident (d/ident (d/db conn) eid))))
-
-        ;; TODO: This should fail, but doesn't, due to stringification of :test/ident.
-        ;; (is (thrown-with-msg?
-        ;;       ExceptionInfo #"Retracting a :db/ident is not yet supported, got "
-        ;;       (<? (d/<transact! conn [[:db/retract 44 :db/ident :test/ident]]))))
-
-        ;; ;; Renaming looks like retraction and then assertion.
-        ;; (is (thrown-with-msg?
-        ;;       ExceptionInfo #"Retracting a :db/ident is not yet supported, got"
-        ;;       (<? (d/<transact! conn [[:db/add 44 :db/ident :other-name]]))))
-
-        ;; (is (thrown-with-msg?
-        ;;       ExceptionInfo #"Re-asserting a :db/ident is not yet supported, got"
-        ;;       (<? (d/<transact! conn [[:db/add 55 :db/ident :test/ident]]))))
-
-        (finally
-          (<? (d/<close conn)))))))
-
-(deftest-async test-add-schema
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [es       [[:db/add :db.part/db :db.install/attribute (d/id-literal :db.part/db -1)]
-                        {:db/id (d/id-literal :db.part/db -1)
-                         :db/ident :test/attr
-                         :db/valueType :db.type/string
-                         :db/cardinality :db.cardinality/one}]
-              report   (<? (d/<transact! conn es))
-              db-after (:db-after report)
-              tx       (:tx db-after)]
-
-          (testing "New ident is allocated"
-            (is (some? (d/entid db-after :test/attr))))
-
-          (testing "Schema is modified"
-            (is (= (get-in db-after [:symbolic-schema :test/attr])
-                   {:db/valueType :db.type/string,
-                    :db/cardinality :db.cardinality/one})))
-
-          (testing "Schema is used in subsequent transaction"
-            (<? (d/<transact! conn [{:db/id 100 :test/attr "value 1"}]))
-            (<? (d/<transact! conn [{:db/id 100 :test/attr "value 2"}]))
-            (is (= (<? (<shallow-entity (d/db conn) 100))
-                   {:test/attr "value 2"}))))
-
-        (finally
-          (<? (d/<close conn)))))))
-
-(deftest-async test-fulltext
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))
-          schema [{:db/id (d/id-literal :db.part/db -1)
-                   :db/ident :test/fulltext
+(deftest-db test-add-schema conn
+  (let [es       [[:db/add :db.part/db :db.install/attribute (d/id-literal :db.part/db -1)]
+                  {:db/id (d/id-literal :db.part/db -1)
+                   :db/ident :test/attr
                    :db/valueType :db.type/string
-                   :db/fulltext true
-                   :db/unique :db.unique/identity}
-                  {:db/id :db.part/db :db.install/attribute (d/id-literal :db.part/db -1)}
-                  {:db/id (d/id-literal :db.part/db -2)
-                   :db/ident :test/other
-                   :db/valueType :db.type/string
-                   :db/fulltext true
-                   :db/cardinality :db.cardinality/one}
-                  {:db/id :db.part/db :db.install/attribute (d/id-literal :db.part/db -2)}
-                  ]
-          tx0 (:tx (<? (d/<transact! conn schema)))]
-      (testing "Schema checks"
-               (is (ds/fulltext? (d/schema (d/db conn))
-                                 (d/entid (d/db conn) :test/fulltext))))
-      (try
-        (testing "Can add fulltext indexed datoms"
-          (let [{tx1 :tx txInstant1 :txInstant}
-                (<? (d/<transact! conn [[:db/add 101 :test/fulltext "test this"]]))]
+                   :db/cardinality :db.cardinality/one}]
+        report   (<? (d/<transact! conn es))
+        db-after (:db-after report)
+        tx       (:tx db-after)]
+
+    (testing "New ident is allocated"
+      (is (some? (d/entid db-after :test/attr))))
+
+    (testing "Schema is modified"
+      (is (= (get-in db-after [:symbolic-schema :test/attr])
+             {:db/valueType :db.type/string,
+              :db/cardinality :db.cardinality/one})))
+
+    (testing "Schema is used in subsequent transaction"
+      (<? (d/<transact! conn [{:db/id 100 :test/attr "value 1"}]))
+      (<? (d/<transact! conn [{:db/id 100 :test/attr "value 2"}]))
+      (is (= (<? (<shallow-entity (d/db conn) 100))
+             {:test/attr "value 2"})))))
+
+(deftest-db test-fulltext conn
+  (let [schema [{:db/id (d/id-literal :db.part/db -1)
+                 :db/ident :test/fulltext
+                 :db/valueType :db.type/string
+                 :db/fulltext true
+                 :db/unique :db.unique/identity}
+                {:db/id :db.part/db :db.install/attribute (d/id-literal :db.part/db -1)}
+                {:db/id (d/id-literal :db.part/db -2)
+                 :db/ident :test/other
+                 :db/valueType :db.type/string
+                 :db/fulltext true
+                 :db/cardinality :db.cardinality/one}
+                {:db/id :db.part/db :db.install/attribute (d/id-literal :db.part/db -2)}
+                ]
+        tx0 (:tx (<? (d/<transact! conn schema)))]
+    (testing "Schema checks"
+      (is (ds/fulltext? (d/schema (d/db conn))
+                        (d/entid (d/db conn) :test/fulltext))))
+
+    (testing "Can add fulltext indexed datoms"
+      (let [{tx1 :tx txInstant1 :txInstant}
+            (<? (d/<transact! conn [[:db/add 101 :test/fulltext "test this"]]))]
+        (is (= (<? (<fulltext-values (d/db conn)))
+               [[1 "test this"]]))
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[101 :test/fulltext 1]})) ;; Values are raw; 1 is the rowid into fulltext_values.
+        (is (= (<? (<transactions-after (d/db conn) tx0))
+               [[101 :test/fulltext 1 tx1 1] ;; Values are raw; 1 is the rowid into fulltext_values.
+                [tx1 :db/txInstant txInstant1 tx1 1]]))
+
+        (testing "Can replace fulltext indexed datoms"
+          (let [{tx2 :tx txInstant2 :txInstant} (<? (d/<transact! conn [[:db/add 101 :test/fulltext "alternate thing"]]))]
             (is (= (<? (<fulltext-values (d/db conn)))
-                   [[1 "test this"]]))
+                   [[1 "test this"]
+                    [2 "alternate thing"]]))
             (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[101 :test/fulltext 1]})) ;; Values are raw; 1 is the rowid into fulltext_values.
+                   #{[101 :test/fulltext 2]})) ;; Values are raw; 2 is the rowid into fulltext_values.
             (is (= (<? (<transactions-after (d/db conn) tx0))
                    [[101 :test/fulltext 1 tx1 1] ;; Values are raw; 1 is the rowid into fulltext_values.
-                    [tx1 :db/txInstant txInstant1 tx1 1]]))
+                    [tx1 :db/txInstant txInstant1 tx1 1]
+                    [101 :test/fulltext 1 tx2 0] ;; Values are raw; 1 is the rowid into fulltext_values.
+                    [101 :test/fulltext 2 tx2 1] ;; Values are raw; 2 is the rowid into fulltext_values.
+                    [tx2 :db/txInstant txInstant2 tx2 1]]))
 
-            (testing "Can replace fulltext indexed datoms"
-              (let [{tx2 :tx txInstant2 :txInstant} (<? (d/<transact! conn [[:db/add 101 :test/fulltext "alternate thing"]]))]
+            (testing "Can upsert keyed by fulltext indexed datoms"
+              (let [{tx3 :tx txInstant3 :txInstant} (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user) :test/fulltext "alternate thing" :test/other "other"}]))]
                 (is (= (<? (<fulltext-values (d/db conn)))
                        [[1 "test this"]
-                        [2 "alternate thing"]]))
+                        [2 "alternate thing"]
+                        [3 "other"]]))
                 (is (= (<? (<datoms-after (d/db conn) tx0))
-                       #{[101 :test/fulltext 2]})) ;; Values are raw; 2 is the rowid into fulltext_values.
+                       #{[101 :test/fulltext 2] ;; Values are raw; 2, 3 are the rowids into fulltext_values.
+                         [101 :test/other 3]}))
                 (is (= (<? (<transactions-after (d/db conn) tx0))
                        [[101 :test/fulltext 1 tx1 1] ;; Values are raw; 1 is the rowid into fulltext_values.
                         [tx1 :db/txInstant txInstant1 tx1 1]
                         [101 :test/fulltext 1 tx2 0] ;; Values are raw; 1 is the rowid into fulltext_values.
                         [101 :test/fulltext 2 tx2 1] ;; Values are raw; 2 is the rowid into fulltext_values.
-                        [tx2 :db/txInstant txInstant2 tx2 1]]))
+                        [tx2 :db/txInstant txInstant2 tx2 1]
+                        [101 :test/other 3 tx3 1] ;; Values are raw; 3 is the rowid into fulltext_values.
+                        [tx3 :db/txInstant txInstant3 tx3 1]]))
 
-                (testing "Can upsert keyed by fulltext indexed datoms"
-                  (let [{tx3 :tx txInstant3 :txInstant} (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user) :test/fulltext "alternate thing" :test/other "other"}]))]
-                    (is (= (<? (<fulltext-values (d/db conn)))
-                           [[1 "test this"]
-                            [2 "alternate thing"]
-                            [3 "other"]]))
-                    (is (= (<? (<datoms-after (d/db conn) tx0))
-                           #{[101 :test/fulltext 2] ;; Values are raw; 2, 3 are the rowids into fulltext_values.
-                             [101 :test/other 3]}))
-                    (is (= (<? (<transactions-after (d/db conn) tx0))
-                           [[101 :test/fulltext 1 tx1 1] ;; Values are raw; 1 is the rowid into fulltext_values.
-                            [tx1 :db/txInstant txInstant1 tx1 1]
-                            [101 :test/fulltext 1 tx2 0] ;; Values are raw; 1 is the rowid into fulltext_values.
-                            [101 :test/fulltext 2 tx2 1] ;; Values are raw; 2 is the rowid into fulltext_values.
-                            [tx2 :db/txInstant txInstant2 tx2 1]
-                            [101 :test/other 3 tx3 1] ;; Values are raw; 3 is the rowid into fulltext_values.
-                            [tx3 :db/txInstant txInstant3 tx3 1]]))
+                ))))))
 
-                    ))))))
+    (testing "Can re-use fulltext indexed datoms"
+      (let [r (<? (d/<transact! conn [[:db/add 102 :test/other "test this"]]))]
+        (is (= (<? (<fulltext-values (d/db conn)))
+               [[1 "test this"]
+                [2 "alternate thing"]
+                [3 "other"]]))
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[101 :test/fulltext 2]
+                 [101 :test/other 3]
+                 [102 :test/other 1]})) ;; Values are raw; 1, 2, 3 are the rowids into fulltext_values.
+        ))
 
-        (testing "Can re-use fulltext indexed datoms"
-          (let [r (<? (d/<transact! conn [[:db/add 102 :test/other "test this"]]))]
-            (is (= (<? (<fulltext-values (d/db conn)))
-                   [[1 "test this"]
-                    [2 "alternate thing"]
-                    [3 "other"]]))
-            (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[101 :test/fulltext 2]
-                     [101 :test/other 3]
-                     [102 :test/other 1]})) ;; Values are raw; 1, 2, 3 are the rowids into fulltext_values.
-            ))
+    (testing "Can retract fulltext indexed datoms"
+      (let [r (<? (d/<transact! conn [[:db/retract 101 :test/fulltext "alternate thing"]]))]
+        (is (= (<? (<fulltext-values (d/db conn)))
+               [[1 "test this"]
+                [2 "alternate thing"]
+                [3 "other"]]))
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[101 :test/other 3]
+                 [102 :test/other 1]})) ;; Values are raw; 1, 3 are the rowids into fulltext_values.
+        ))))
 
-        (testing "Can retract fulltext indexed datoms"
-          (let [r (<? (d/<transact! conn [[:db/retract 101 :test/fulltext "alternate thing"]]))]
-            (is (= (<? (<fulltext-values (d/db conn)))
-                   [[1 "test this"]
-                    [2 "alternate thing"]
-                    [3 "other"]]))
-            (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[101 :test/other 3]
-                     [102 :test/other 1]})) ;; Values are raw; 1, 3 are the rowids into fulltext_values.
-            ))
+(deftest-db test-txInstant conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))
+        {txa :tx txInstantA :txInstant} (<? (d/<transact! conn []))]
+    (testing ":db/txInstant is set by default"
+      (is (= (<? (<transactions-after (d/db conn) tx0))
+             [[txa :db/txInstant txInstantA txa 1]])))
 
-        (finally
-          (<? (d/<close conn)))))))
+    ;; TODO: range check txInstant values against DB clock.
+    (testing ":db/txInstant can be set explicitly"
+      (let [{txb :tx txInstantB :txInstant} (<? (d/<transact! conn [[:db/add :db/tx :db/txInstant (+ txInstantA 1)]]))]
+        (is (= txInstantB (+ txInstantA 1)))
+        (is (= (<? (<transactions-after (d/db conn) txa))
+               [[txb :db/txInstant txInstantB txb 1]]))
 
-(deftest-async test-txInstant
-  (with-tempfile [t (tempfile)]
-    (let [conn      (<? (d/<connect t))
-          {tx0 :tx} (<? (d/<transact! conn test-schema))]
-      (try
-        (let [{txa :tx txInstantA :txInstant} (<? (d/<transact! conn []))]
-          (testing ":db/txInstant is set by default"
-            (is (= (<? (<transactions-after (d/db conn) tx0))
-                   [[txa :db/txInstant txInstantA txa 1]])))
+        (testing ":db/txInstant can be set explicitly, with additional datoms"
+          (let [{txc :tx txInstantC :txInstant} (<? (d/<transact! conn [[:db/add :db/tx :db/txInstant (+ txInstantB 2)]
+                                                                        [:db/add :db/tx :x 123]]))]
+            (is (= txInstantC (+ txInstantB 2)))
+            (is (= (<? (<transactions-after (d/db conn) txb))
+                   [[txc :db/txInstant txInstantC txc 1]
+                    [txc :x 123 txc 1]]))
 
-          ;; TODO: range check txInstant values against DB clock.
-          (testing ":db/txInstant can be set explicitly"
-            (let [{txb :tx txInstantB :txInstant} (<? (d/<transact! conn [[:db/add :db/tx :db/txInstant (+ txInstantA 1)]]))]
-              (is (= txInstantB (+ txInstantA 1)))
-              (is (= (<? (<transactions-after (d/db conn) txa))
-                     [[txb :db/txInstant txInstantB txb 1]]))
+            (testing "additional datoms can be added, without :db/txInstant explicitly"
+              (let [{txd :tx txInstantD :txInstant} (<? (d/<transact! conn [[:db/add :db/tx :x 456]]))]
+                (is (= (<? (<transactions-after (d/db conn) txc))
+                       [[txd :db/txInstant txInstantD txd 1]
+                        [txd :x 456 txd 1]]))))))))))
 
-              (testing ":db/txInstant can be set explicitly, with additional datoms"
-                (let [{txc :tx txInstantC :txInstant} (<? (d/<transact! conn [[:db/add :db/tx :db/txInstant (+ txInstantB 2)]
-                                                                              [:db/add :db/tx :x 123]]))]
-                  (is (= txInstantC (+ txInstantB 2)))
-                  (is (= (<? (<transactions-after (d/db conn) txb))
-                         [[txc :db/txInstant txInstantC txc 1]
-                          [txc :x 123 txc 1]]))
+(deftest-db test-no-tx conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))]
+    (testing "Cannot specificy an explicit tx"
+      (is (thrown-with-msg?
+            ExceptionInfo #"Bad entity: too long"
+            (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user) :x 0 10101]])))))))
 
-                  (testing "additional datoms can be added, without :db/txInstant explicitly"
-                    (let [{txd :tx txInstantD :txInstant} (<? (d/<transact! conn [[:db/add :db/tx :x 456]]))]
-                      (is (= (<? (<transactions-after (d/db conn) txc))
-                             [[txd :db/txInstant txInstantD txd 1]
-                              [txd :x 456 txd 1]])))))))))
+(deftest-db test-explode-sequences conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))]
+    (testing ":db.cardinality/many sequences are accepted"
+      (<? (d/<transact! conn [{:db/id 101 :aka ["first" "second"]}]))
+      (is (= (<? (<datoms-after (d/db conn) tx0))
+             #{[101 :aka "first"]
+               [101 :aka "second"]})))
 
-        (finally
-          (<? (d/<close conn)))))))
+    (testing ":db.cardinality/many sequences are recursively applied, allowing unexpected sequence nesting"
+      (<? (d/<transact! conn [{:db/id 102 :aka [[["first"]] ["second"]]}]))
+      (is (= (<? (<datoms-after (d/db conn) tx0))
+             #{[101 :aka "first"]
+               [101 :aka "second"]
+               [102 :aka "first"]
+               [102 :aka "second"]})))
 
-(deftest-async test-no-tx
-  (with-tempfile [t (tempfile)]
-    (let [conn      (<? (d/<connect t))
-          {tx0 :tx} (<? (d/<transact! conn test-schema))]
-      (try
-        (testing "Cannot specificy an explicit tx"
-          (is (thrown-with-msg?
-                ExceptionInfo #"Bad entity: too long"
-                (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user) :x 0 10101]])))))
+    (testing ":db.cardinality/one sequences fail"
+      (is (thrown-with-msg?
+            ExceptionInfo #"Sequential values"
+            (<? (d/<transact! conn [{:db/id 101 :email ["@1" "@2"]}])))))))
 
-        (finally
-          (<? (d/<close conn)))))))
+(deftest-db test-explode-maps conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))]
+    (testing "nested maps are accepted"
+      (<? (d/<transact! conn [{:db/id 101 :friends {:name "Petr"}}]))
+      ;; TODO: this works only because we have a single friend.
+      (let [{petr :friends} (<? (<shallow-entity (d/db conn) 101))]
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[101 :friends petr]
+                 [petr :name "Petr"]}))))
 
-(deftest-async test-explode-sequences
-  (with-tempfile [t (tempfile)]
-    (let [conn      (<? (d/<connect t))
-          {tx0 :tx} (<? (d/<transact! conn test-schema))]
-      (try
-        (testing ":db.cardinality/many sequences are accepted"
-          (<? (d/<transact! conn [{:db/id 101 :aka ["first" "second"]}]))
-          (is (= (<? (<datoms-after (d/db conn) tx0))
-                 #{[101 :aka "first"]
-                   [101 :aka "second"]})))
+    (testing "recursively nested maps are accepted"
+      (<? (d/<transact! conn [{:db/id 102 :friends {:name "Ivan" :friends {:name "Petr"}}}]))
+      ;; This would be much easier with `entity` and lookup refs.
+      (let [{ivan :friends} (<? (<shallow-entity (d/db conn) 102))
+            {petr :friends} (<? (<shallow-entity (d/db conn) ivan))]
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[101 :friends petr]
+                 [petr :name "Petr"]
+                 [102 :friends ivan]
+                 [ivan :name "Ivan"]
+                 [ivan :friends petr]}))))
 
-        (testing ":db.cardinality/many sequences are recursively applied, allowing unexpected sequence nesting"
-          (<? (d/<transact! conn [{:db/id 102 :aka [[["first"]] ["second"]]}]))
-          (is (= (<? (<datoms-after (d/db conn) tx0))
-                 #{[101 :aka "first"]
-                   [101 :aka "second"]
-                   [102 :aka "first"]
-                   [102 :aka "second"]})))
+    (testing "nested maps without :db.type/ref fail"
+      (is (thrown-with-msg?
+            ExceptionInfo #"\{:db/valueType :db.type/ref\}"
+            (<? (d/<transact! conn [{:db/id 101 :aka {:name "Petr"}}])))))))
 
-        (testing ":db.cardinality/one sequences fail"
-          (is (thrown-with-msg?
-                ExceptionInfo #"Sequential values"
-                (<? (d/<transact! conn [{:db/id 101 :email ["@1" "@2"]}])))))
+(deftest-db test-explode-reverse-refs conn
+  (let [{tx0 :tx} (<? (d/<transact! conn test-schema))]
+    (testing "reverse refs are accepted"
+      (<? (d/<transact! conn [{:db/id 101 :name "Igor"}]))
+      (<? (d/<transact! conn [{:db/id 102 :name "Oleg" :_friends 101}]))
+      (is (= (<? (<datoms-after (d/db conn) tx0))
+             #{[101 :name "Igor"]
+               [102 :name "Oleg"]
+               [101 :friends 102]})))
 
-        (finally
-          (<? (d/<close conn)))))))
+    (testing "reverse refs without :db.type/ref fail"
+      (is (thrown-with-msg?
+            ExceptionInfo #"\{:db/valueType :db.type/ref\}"
+            (<? (d/<transact! conn [{:db/id 101 :_aka 102}])))))))
 
-(deftest-async test-explode-maps
-  (with-tempfile [t (tempfile)]
-    (let [conn      (<? (d/<connect t))
-          {tx0 :tx} (<? (d/<transact! conn test-schema))]
-      (try
-        (testing "nested maps are accepted"
-          (<? (d/<transact! conn [{:db/id 101 :friends {:name "Petr"}}]))
-          ;; TODO: this works only because we have a single friend.
-          (let [{petr :friends} (<? (<shallow-entity (d/db conn) 101))]
-            (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[101 :friends petr]
-                     [petr :name "Petr"]}))))
-
-        (testing "recursively nested maps are accepted"
-          (<? (d/<transact! conn [{:db/id 102 :friends {:name "Ivan" :friends {:name "Petr"}}}]))
-          ;; This would be much easier with `entity` and lookup refs.
-          (let [{ivan :friends} (<? (<shallow-entity (d/db conn) 102))
-                {petr :friends} (<? (<shallow-entity (d/db conn) ivan))]
-            (is (= (<? (<datoms-after (d/db conn) tx0))
-                   #{[101 :friends petr]
-                     [petr :name "Petr"]
-                     [102 :friends ivan]
-                     [ivan :name "Ivan"]
-                     [ivan :friends petr]}))))
-
-        (testing "nested maps without :db.type/ref fail"
-          (is (thrown-with-msg?
-                ExceptionInfo #"\{:db/valueType :db.type/ref\}"
-                (<? (d/<transact! conn [{:db/id 101 :aka {:name "Petr"}}])))))
-
-        (finally
-          (<? (d/<close conn)))))))
-
-(deftest-async test-explode-reverse-refs
-  (with-tempfile [t (tempfile)]
-    (let [conn      (<? (d/<connect t))
-          {tx0 :tx} (<? (d/<transact! conn test-schema))]
-      (try
-        (testing "reverse refs are accepted"
-          (<? (d/<transact! conn [{:db/id 101 :name "Igor"}]))
-          (<? (d/<transact! conn [{:db/id 102 :name "Oleg" :_friends 101}]))
-          (is (= (<? (<datoms-after (d/db conn) tx0))
-                 #{[101 :name "Igor"]
-                   [102 :name "Oleg"]
-                   [101 :friends 102]})))
-
-        (testing "reverse refs without :db.type/ref fail"
-          (is (thrown-with-msg?
-                ExceptionInfo #"\{:db/valueType :db.type/ref\}"
-                (<? (d/<transact! conn [{:db/id 101 :_aka 102}])))))
-
-        (finally
-          (<? (d/<close conn)))))))
-
+;; We don't use deftest-db in order to be able to re-open an on disk file.
 (deftest-async test-next-eid
   (with-tempfile [t (tempfile)]
     (let [conn      (<? (d/<connect t))
@@ -644,34 +548,30 @@
               (finally
                 (<? (d/<close conn))))))))))
 
-(deftest-async test-unique-value
-  (with-tempfile [t (tempfile)]
-    (let [conn (<? (d/<connect t))]
-      (try
-        (let [tx0 (:tx (<? (d/<transact! conn [{:db/id                 (d/id-literal :db.part/user -1)
-                                                :db/ident              :test/x
-                                                :db/unique             :db.unique/value
-                                                :db/valueType          :db.type/long
-                                                :db.install/_attribute :db.part/db}
-                                               {:db/id                 (d/id-literal :db.part/user -2)
-                                                :db/ident              :test/y
-                                                :db/unique             :db.unique/value
-                                                :db/valueType          :db.type/long
-                                                :db.install/_attribute :db.part/db}])))]
+(deftest-db test-unique-value conn
+  (let [tx0 (:tx (<? (d/<transact! conn [{:db/id                 (d/id-literal :db.part/user -1)
+                                          :db/ident              :test/x
+                                          :db/unique             :db.unique/value
+                                          :db/valueType          :db.type/long
+                                          :db.install/_attribute :db.part/db}
+                                         {:db/id                 (d/id-literal :db.part/user -2)
+                                          :db/ident              :test/y
+                                          :db/unique             :db.unique/value
+                                          :db/valueType          :db.type/long
+                                          :db.install/_attribute :db.part/db}])))]
 
-          (testing "can insert different :db.unique/value attributes with the same value"
-            (let [report1 (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :test/x 12345]]))
-                  eid1    (get-in report1 [:tempids (d/id-literal :db.part/user -1)])
-                  report2 (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -2) :test/y 12345]]))
-                  eid2    (get-in report2 [:tempids (d/id-literal :db.part/user -2)])]
-              (is (= (<? (<datoms-after (d/db conn) tx0))
-                     #{[eid1 :test/x 12345]
-                       [eid2 :test/y 12345]}))))
+    (testing "can insert different :db.unique/value attributes with the same value"
+      (let [report1 (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -1) :test/x 12345]]))
+            eid1    (get-in report1 [:tempids (d/id-literal :db.part/user -1)])
+            report2 (<? (d/<transact! conn [[:db/add (d/id-literal :db.part/user -2) :test/y 12345]]))
+            eid2    (get-in report2 [:tempids (d/id-literal :db.part/user -2)])]
+        (is (= (<? (<datoms-after (d/db conn) tx0))
+               #{[eid1 :test/x 12345]
+                 [eid2 :test/y 12345]}))))
 
-          (testing "can't upsert a :db.unique/value field"
-            (is (thrown-with-msg?
-                  ExceptionInfo #"unique constraint"
-                  (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :test/x 12345 :test/y 99999}]))))))
+    (testing "can't upsert a :db.unique/value field"
+      (is (thrown-with-msg?
+            ExceptionInfo #"unique constraint"
+            (<? (d/<transact! conn [{:db/id (d/id-literal :db.part/user -1) :test/x 12345 :test/y 99999}])))))))
 
-        (finally
-          (<? (d/<close conn)))))))
+#_ (time (t/run-tests))

--- a/test/datomish/db_test.cljc
+++ b/test/datomish/db_test.cljc
@@ -781,4 +781,34 @@
                    ;; [eid2 :test/ref eid1] is gone, since the ref eid1 is gone.
                    #{}))))))))
 
+;; We don't use deftest-db in order to be able to re-open an on disk file.
+(deftest-async test-reopen-schema
+  (with-tempfile [t (tempfile)]
+    (let [conn        (<? (d/<connect t))
+          test-schema [{:db/id                 (d/id-literal :db.part/user -1)
+                        :db/ident              :test/fulltext
+                        :db/cardinality        :db.cardinality/many
+                        :db/valueType          :db.type/string
+                        :db/fulltext           true
+                        :db.install/_attribute :db.part/db}]
+          {tx0 :tx}   (<? (d/<transact! conn test-schema))]
+      (testing "Boolean values in schema are correct initially"
+        (let [db     (d/db conn)
+              schema (d/schema db)]
+          (is (= true (ds/indexing? schema (d/entid db :db/txInstant))))
+          (is (= true (ds/fulltext? schema (d/entid db :test/fulltext))))))
+
+      ;; Close and re-open same DB.
+      (<? (d/<close conn))
+      (let [conn (<? (d/<connect t))]
+        (try
+          (testing "Boolean values in schema are correct after re-opening"
+            (let [db     (d/db conn)
+                  schema (d/schema db)]
+              (is (= true (ds/indexing? schema (d/entid db :db/txInstant))))
+              (is (= true (ds/fulltext? schema (d/entid db :test/fulltext))))))
+
+          (finally
+            (<? (d/<close conn))))))))
+
 #_ (time (t/run-tests))


### PR DESCRIPTION
@rnewman, over to you.

I put the test first so that I could verify it failed before the patch.  Will land together to not break (future?) CI :)